### PR TITLE
prevent app crashes

### DIFF
--- a/controller/generatePdf.js
+++ b/controller/generatePdf.js
@@ -6,7 +6,11 @@ const generatePdf = async (url) => {
     args: ["--no-sandbox", "--disable-setuid-sandbox"], // SEE BELOW WARNING!!!
   });
   const page = await browser.newPage();
-  await page.goto(url);
+  try{
+    await page.goto(url);    
+  } catch(e) {
+    console.error(e);
+  }
   const pdf = await page.pdf();
   await browser.close();
   // Return Buffer


### PR DESCRIPTION
app stops working when provided url is inappropriate now so added try-catch.
when the url is not ok, it will make blank pdf instead of being crashed